### PR TITLE
[UR] Make /DEPENDENTLOADFLAG value configurable

### DIFF
--- a/unified-runtime/CMakeLists.txt
+++ b/unified-runtime/CMakeLists.txt
@@ -67,6 +67,10 @@ set(UR_ADAPTER_HIP_SOURCE_DIR "" CACHE PATH
     "Path to external 'hip' adapter source dir")
 set(UR_ADAPTER_NATIVE_CPU_SOURCE_DIR "" CACHE PATH
     "Path to external 'native_cpu' adapter source dir")
+if(CMAKE_SYSTEM_NAME STREQUAL Windows)
+    set(UR_DEPENDENTLOADFLAG "0x2000" CACHE STRING
+        "Value to use for Windows link.exe /DEPENDENTLOADFLAG option")
+endif()
 
 list(APPEND CMAKE_MODULE_PATH "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 include(helpers)

--- a/unified-runtime/cmake/helpers.cmake
+++ b/unified-runtime/cmake/helpers.cmake
@@ -194,9 +194,9 @@ function(add_ur_library name)
     add_library(${name} ${ARGN})
     add_ur_target_compile_options(${name})
     add_ur_target_link_options(${name})
-    if(MSVC)
+    if(CMAKE_LINKER MATCHES link.exe)
         target_link_options(${name} PRIVATE
-            $<$<STREQUAL:$<TARGET_LINKER_FILE_NAME:${name}>,link.exe>:LINKER:/DEPENDENTLOADFLAG:0x2000>
+            LINKER:/DEPENDENTLOADFLAG:${UR_DEPENDENTLOADFLAG}
         )
     endif()
 endfunction()


### PR DESCRIPTION
Migrated from https://github.com/oneapi-src/unified-runtime/pull/2235

In Windows development environments the default value of `0x2000` is too restrictive as it does not allow loading the `OpenCL.dll` built as part of the project. This patch makes the value passed to the `/DEPENDENTLOADFLAG` option configurable using the `UR_DEPENDENTLOADFLAG` CMake option.
